### PR TITLE
- non static value produces error *

### DIFF
--- a/src/Hook.php
+++ b/src/Hook.php
@@ -39,7 +39,7 @@ use QuickTemplate;
 use User;
 
 class Hook {
-	private $userBeforeLogout;
+	static private $userBeforeLogout;
 
 	/**
 	 * Handler for the UserLoginComplete hook


### PR DESCRIPTION
* PHP Fatal error:  Access to undeclared static property: MediaWiki\\Extension\\UserLoginLog\\Hook::$userBeforeLogout in /extensions/UserLoginLog/src/Hook.php on line 99