### PR TITLE
- unsupported manifest_version: 2 produces error (on MediaWiki 1.28.0) *

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -45,6 +45,5 @@
 	},
 	"ConfigRegistry": {
 		"userloginlog": "MediaWiki\\Extension\\UserLoginLog\\Config::newInstance"
-	},
-	"manifest_version": 2
+	}
 }


### PR DESCRIPTION
* PHP Fatal error:  Uncaught exception 'Exception' with message ' /extensions/UserLoginLog/extension.json: unsupported manifest_version: 2' in /includes/registration/ExtensionRegistry.php:196\nStack trace:\n#0 /includes/registration/ExtensionRegistry.php(138): ExtensionRegistry->readFromQueue(Array)\n#1 /includes/Setup.php(40): ExtensionRegistry->loadFromQueue()\n#2 /includes/WebStart.php(137): require_once('...')\n#3 /index.php(40): require('...')\n#4 {main}\n  thrown in /includes/registration/ExtensionRegistry.php on line 196